### PR TITLE
修复重复调用_refreshVirtualList

### DIFF
--- a/source/src/fairygui/GList.ts
+++ b/source/src/fairygui/GList.ts
@@ -1100,7 +1100,7 @@ namespace fgui {
             else if (this._virtualListChanged == 0)
                 this._virtualListChanged = 1;
 
-            Laya.timer.callLater(this, this._refreshVirtualList);
+            Laya.timer.frameOnce(1, this, this._refreshVirtualList);
         }
 
         private _refreshVirtualList(): void {


### PR DESCRIPTION
同时调用setVirtual和numItems时会调用两次，而callLater无法clear掉，导致重复调用