### PR TITLE
同步 Laya 3.3 适配 

### DIFF
--- a/source/src/fairygui/AssetProxy.ts
+++ b/source/src/fairygui/AssetProxy.ts
@@ -15,8 +15,14 @@ namespace fgui {
             return this.loader.getRes(url, type);
         }
 
-        getItemRes(item: PackageItem) {
+        public getItemRes(item: PackageItem) {
             return this.getRes(item.file);
+        }
+
+        public clearItemRes(item: PackageItem): void {
+            if (item.file) {
+                Laya.loader.clearRes(item.file);
+            }
         }
 
         public load(url: string | Laya.ILoadURL | (string | Readonly<Laya.ILoadURL>)[], type?: string, onProgress?: Laya.ProgressCallback): Promise<any> {

--- a/source/src/fairygui/DragDropManager.ts
+++ b/source/src/fairygui/DragDropManager.ts
@@ -60,7 +60,7 @@ namespace fgui {
             var sourceData: any = this._sourceData;
             this._sourceData = null;
 
-            var obj: GObject = GObject.cast(evt.target);
+            var obj: GObject = cast(evt.target);
             while (obj) {
                 if (obj.displayObject.hasListener(Events.DROP)) {
                     obj.requestFocus();

--- a/source/src/fairygui/GButton.ts
+++ b/source/src/fairygui/GButton.ts
@@ -503,9 +503,9 @@ namespace fgui {
             if (this._sound) {
                 var pi: PackageItem = UIPackage.getItemByURL(this._sound);
                 if (pi)
-                    GRoot.inst.playOneShotSound(pi.file);
+                    GRoot.inst.playOneShotSound(pi, this._soundVolumeScale);
                 else
-                    GRoot.inst.playOneShotSound(this._sound);
+                    GRoot.inst.playOneShotSound(this._sound, this._soundVolumeScale);
             }
 
             if (this._mode == ButtonMode.Check) {

--- a/source/src/fairygui/GComponent.ts
+++ b/source/src/fairygui/GComponent.ts
@@ -42,6 +42,9 @@ namespace fgui {
         }
 
         public dispose(): void {
+
+            this.onDispose();
+
             var i: number;
             var cnt: number;
 
@@ -1213,6 +1216,9 @@ namespace fgui {
 
         protected onConstruct(): void {
             this.constructFromXML(null); //old version
+        }
+
+        protected onDispose(): void {
         }
 
         protected constructFromXML(xml: Object): void {

--- a/source/src/fairygui/GComponent.ts
+++ b/source/src/fairygui/GComponent.ts
@@ -735,29 +735,28 @@ namespace fgui {
         }
 
         protected setupScroll(buffer: ByteBuffer): void {
-            if (this._displayObject == this._container) {
-                this._container = new Laya.Sprite();
-                this._displayObject.addChild(this._container);
-            }
+            this.createContainer();
             this._scrollPane = new ScrollPane(this);
             this._scrollPane.setup(buffer);
         }
 
         protected setupOverflow(overflow: number): void {
             if (overflow == OverflowType.Hidden) {
-                if (this._displayObject == this._container) {
-                    this._container = new Laya.Sprite();
-                    this._displayObject.addChild(this._container);
-                }
+                this.createContainer();
                 this.updateMask();
                 this._container.pos(this._margin.left, this._margin.top);
             }
             else if (this._margin.left != 0 || this._margin.top != 0) {
-                if (this._displayObject == this._container) {
-                    this._container = new Laya.Sprite();
-                    this._displayObject.addChild(this._container);
-                }
+                this.createContainer();
                 this._container.pos(this._margin.left, this._margin.top);
+            }
+        }
+
+        protected createContainer(): void {
+            if (this._displayObject == this._container) {
+                this._container = new Laya.Sprite();
+                this._container.name = '<Container>';
+                this._displayObject.addChild(this._container);
             }
         }
 

--- a/source/src/fairygui/GList.ts
+++ b/source/src/fairygui/GList.ts
@@ -631,7 +631,7 @@ namespace fgui {
             if (this._scrollPane && this._scrollPane.isDragged)
                 return;
 
-            var item: GObject = GObject.cast(evt.currentTarget);
+            var item: GObject = cast(evt.currentTarget);
             this.setSelectionOnEvent(item, evt);
 
             if (this._scrollPane && this.scrollItemToViewOnClick)

--- a/source/src/fairygui/GList.ts
+++ b/source/src/fairygui/GList.ts
@@ -50,6 +50,7 @@ namespace fgui {
             this._verticalAlign = "top";
 
             this._container = new Laya.Sprite();
+            this._container.name = '<Container>';
             this._displayObject.addChild(this._container);
         }
 

--- a/source/src/fairygui/GLoader.ts
+++ b/source/src/fairygui/GLoader.ts
@@ -32,6 +32,7 @@ namespace fgui {
             super.createDisplayObject();
 
             this._content = new MovieClip();
+            this._content.name = "<Image>";
             this._displayObject.addChild(this._content);
             this._displayObject.mouseEnabled = true;
         }
@@ -272,6 +273,7 @@ namespace fgui {
                     }
                     else {
                         this._content2 = obj.asCom;
+                        this._content2.name = obj.name || this._contentItem.name || "<Content>";
                         this._displayObject.addChild(this._content2.displayObject);
                         this.updateLayout();
                     }
@@ -323,6 +325,7 @@ namespace fgui {
             }
 
             if (this._errorSign) {
+                this._errorSign.name = this._errorSign.name || "<ErrorSign>";
                 this._errorSign.setSize(this.width, this.height);
                 this._displayObject.addChild(this._errorSign.displayObject);
             }

--- a/source/src/fairygui/GLoader3D.ts
+++ b/source/src/fairygui/GLoader3D.ts
@@ -32,6 +32,7 @@ namespace fgui {
             super.createDisplayObject();
 
             this._container = new Laya.Sprite();
+            this._container.name = '<Container>';
             this._displayObject.addChild(this._container);
         }
 

--- a/source/src/fairygui/GLoader3D.ts
+++ b/source/src/fairygui/GLoader3D.ts
@@ -13,8 +13,8 @@ namespace fgui {
         private _skinName: string;
         private _color: string;
         private _contentItem: PackageItem;
-        private _container: Laya.Sprite;
-        private _content: Laya.Skeleton | Laya.SpineSkeleton;
+        protected _container: Laya.Sprite;
+        protected _content: Laya.Sprite;
         private _updatingLayout: boolean;
 
         public constructor() {
@@ -255,28 +255,29 @@ namespace fgui {
         }
 
         private onChange(): void {
-            if (!this._content)
+            if (!this._content || !((Laya.Skeleton && this._content instanceof Laya.Skeleton) || (Laya.SpineSkeleton && this._content instanceof Laya.SpineSkeleton)))
                 return;
 
+            const content = this._content as Laya.Skeleton | Laya.SpineSkeleton;
             if (this._animationName) {
                 if (this._playing)
-                    this._content.play(this._animationName, this._loop);
+                    content.play(this._animationName, this._loop);
                 else
-                    this._content.play(this._animationName, false, true, this._frame, this._frame);
+                    content.play(this._animationName, false, true, this._frame, this._frame);
             }
             else
-                this._content.stop();
+                content.stop();
 
             if (this._skinName)
-                this._content.showSkinByName(this._skinName);
+                content.showSkinByName(this._skinName);
             else
-                this._content.showSkinByIndex(0);
+                content.showSkinByIndex(0);
         }
 
         protected loadExternal(): void {
         }
 
-        private updateLayout(): void {
+        protected updateLayout(): void {
             let cw = this.sourceWidth;
             let ch = this.sourceHeight;
 
@@ -350,7 +351,7 @@ namespace fgui {
             this._container.pos(nx, ny);
         }
 
-        private clearContent(): void {
+        protected clearContent(): void {
             if (this._content) {
                 this._container.removeChild(this._content);
                 this._content.destroy();

--- a/source/src/fairygui/GLoader3D.ts
+++ b/source/src/fairygui/GLoader3D.ts
@@ -37,6 +37,7 @@ namespace fgui {
         }
 
         public dispose(): void {
+            this.clearContent();
             super.dispose();
         }
 
@@ -232,17 +233,16 @@ namespace fgui {
             if (!templet)
                 return;
 
-            if (templet instanceof Laya.Templet)
+            if (Laya.Templet && templet instanceof Laya.Templet)
                 this.setSkeleton(templet.buildArmature(1), this._contentItem.skeletonAnchor);
-            else {
+            else if (Laya.SpineSkeleton && templet instanceof Laya.SpineTemplet) {
                 let obj = new Laya.SpineSkeleton();
-                obj.templet = templet;
+                obj.templet = templet as Laya.SpineTemplet;
                 this.setSkeleton(obj, this._contentItem.skeletonAnchor);
             }
         }
 
         public setSkeleton(skeleton: Laya.Skeleton | Laya.SpineSkeleton, anchor?: Laya.Point): void {
-            this.url = null;
 
             this._content = skeleton;
             this._container.addChild(this._content);
@@ -351,11 +351,14 @@ namespace fgui {
         }
 
         private clearContent(): void {
-            this._contentItem = null;
             if (this._content) {
                 this._container.removeChild(this._content);
                 this._content.destroy();
                 this._content = null;
+            }
+            if (this._contentItem && !this._contentItem.loading) {
+                AssetProxy.inst.clearItemRes(this._contentItem);
+                this._contentItem = null;
             }
         }
 

--- a/source/src/fairygui/GObject.ts
+++ b/source/src/fairygui/GObject.ts
@@ -1201,16 +1201,16 @@ namespace fgui {
             }
         }
         //-------------------------------------------------------------------
-
-        public static cast(sprite: Laya.Sprite): GObject {
-            return <GObject>(sprite["$owner"]);
-        }
     }
 
     export const BlendMode = {
         2: Laya.BlendMode.LIGHTER,
         //3: Laya.BlendMode.MULTIPLY,
         //4: Laya.BlendMode.SCREEN
+    }
+
+    export function cast<T extends GObject>(sprite: Laya.Sprite): T {
+        return <T>(sprite["$owner"]);
     }
 
     var _gInstanceCounter: number = 0;

--- a/source/src/fairygui/GObject.ts
+++ b/source/src/fairygui/GObject.ts
@@ -78,6 +78,9 @@ namespace fgui {
 
         public set name(value: string) {
             this._name = value;
+            if (this.displayObject) {
+                this._displayObject.name = value;
+            }
         }
 
         public get x(): number {
@@ -991,7 +994,7 @@ namespace fgui {
             var f2: number;
 
             this._id = buffer.readS();
-            this._name = buffer.readS();
+            this.name = buffer.readS();
             f1 = buffer.getInt32();
             f2 = buffer.getInt32();
             this.setXY(f1, f2);

--- a/source/src/fairygui/GObject.ts
+++ b/source/src/fairygui/GObject.ts
@@ -784,8 +784,9 @@ namespace fgui {
             return this._displayObject.hasListener(Laya.Event.CLICK);
         }
 
-        public on(type: string, thisObject: any, listener: Function, args?: any[]): void {
+        public on(type: string, thisObject: any, listener: Function, args?: any[]) {
             this._displayObject.on(type, thisObject, listener, args);
+            return listener;
         }
 
         public off(type: string, thisObject: any, listener: Function): void {

--- a/source/src/fairygui/GRoot.ts
+++ b/source/src/fairygui/GRoot.ts
@@ -26,7 +26,7 @@ namespace fgui {
             this.opaque = false;
             this._popupStack = [];
             this._justClosedPopups = [];
-            this.displayObject.once(Laya.Event.DISPLAY, this, this.__addedToStage);
+            this.displayObject.once(Laya.Event.ADDED, this, this.__addedToStage);
         }
 
         public showWindow(win: Window): void {

--- a/source/src/fairygui/GRoot.ts
+++ b/source/src/fairygui/GRoot.ts
@@ -308,10 +308,19 @@ namespace fgui {
             Laya.SoundManager.soundVolume = value;
         }
 
-        public playOneShotSound(url: string, volumeScale?: number): void {
-            if (ToolSet.startsWith(url, "ui://"))
-                return;
-
+        public playOneShotSound(url: string, volumeScale?: number);
+        public playOneShotSound(url: PackageItem, volumeScale?: number);
+        public playOneShotSound(item: string | PackageItem, volumeScale?: number) {
+            let url: string;
+            if (typeof item === 'string') {
+                url = item;
+                if (ToolSet.startsWith(url, "ui://")) {
+                    item = UIPackage.getItemByURL(url);
+                }
+            }
+            if (item) {
+                url = (item as PackageItem).file;
+            }
             Laya.SoundManager.playSound(url);
         }
 

--- a/source/src/fairygui/GRoot.ts
+++ b/source/src/fairygui/GRoot.ts
@@ -26,6 +26,7 @@ namespace fgui {
             this.opaque = false;
             this._popupStack = [];
             this._justClosedPopups = [];
+            this.name = 'GRoot';
             this.displayObject.once(Laya.Event.ADDED, this, this.__addedToStage);
         }
 

--- a/source/src/fairygui/GTree.ts
+++ b/source/src/fairygui/GTree.ts
@@ -315,7 +315,7 @@ namespace fgui {
         }
 
         private __cellMouseDown(evt: Laya.Event): void {
-            var node: GTreeNode = GObject.cast(evt.currentTarget)._treeNode;
+            var node: GTreeNode = cast(evt.currentTarget)._treeNode;
             this._expandedStatusInEvt = node.expanded;
         }
 

--- a/source/src/fairygui/ScrollPane.ts
+++ b/source/src/fairygui/ScrollPane.ts
@@ -68,6 +68,7 @@ namespace fgui {
             this._owner = owner;
 
             this._maskContainer = new Laya.Sprite();
+            this._maskContainer.name = '<ScrollPane>';
             this._owner.displayObject.addChild(this._maskContainer);
 
             this._container = this._owner._container;

--- a/source/src/fairygui/Transition.ts
+++ b/source/src/fairygui/Transition.ts
@@ -1003,7 +1003,7 @@ namespace fgui {
                         if (value.audioClip == null) {
                             var pi: PackageItem = UIPackage.getItemByURL(value.sound);
                             if (pi)
-                                value.audioClip = pi.file;
+                                value.audioClip = pi;
                             else
                                 value.audioClip = value.sound;
                         }

--- a/source/src/fairygui/UIConfig.ts
+++ b/source/src/fairygui/UIConfig.ts
@@ -3,9 +3,14 @@ namespace fgui {
     constructor() {
     }
 
+    public static fontRemaps: Record<string, string> = {};
+    protected static _defaultFont: string = Laya.Config.defaultFont;
+
     //Default font name
-    public static get defaultFont() { return Laya.Config.defaultFont; }
-    public static set defaultFont(value: string) { Laya.Config.defaultFont = value; }
+    public static get defaultFont() { return this._defaultFont; }
+    public static set defaultFont(value: string) {
+      Laya.Config.defaultFont = this._defaultFont = this.fontRemaps[value] || value;
+    }
 
     //Resource using in Window.ShowModalWait for locking the window.
     public static windowModalWaiting: string;

--- a/source/src/fairygui/UIPackage.ts
+++ b/source/src/fairygui/UIPackage.ts
@@ -589,10 +589,7 @@ namespace fgui {
 
         public getItemAssetByName(resName: string): any {
             var pi: PackageItem = this._itemsByName[resName];
-            if (pi == null) {
-                throw "Resource not found -" + resName;
-            }
-
+            if (!pi) return null;
             return this.getItemAsset(pi);
         }
 
@@ -643,7 +640,7 @@ namespace fgui {
 
                 case PackageItemType.Component:
                     return item.rawData;
-
+                case PackageItemType.Sound:
                 case PackageItemType.Misc:
                     if (item.file)
                         return AssetProxy.inst.getItemRes(item);

--- a/source/src/fairygui/UIPackage.ts
+++ b/source/src/fairygui/UIPackage.ts
@@ -565,7 +565,7 @@ namespace fgui {
 
         public internalCreateObject(item: PackageItem, userClass?: new () => GObject): GObject {
             var g: GObject = UIObjectFactory.newObject(item, userClass);
-
+            g.name = g.name || item.name;
             if (g == null)
                 return null;
 

--- a/source/src/fairygui/Window.ts
+++ b/source/src/fairygui/Window.ts
@@ -286,7 +286,7 @@ namespace fgui {
         }
 
         private __dragStart(evt: Laya.Event): void {
-            GObject.cast(evt.currentTarget).stopDrag();
+            cast(evt.currentTarget).stopDrag();
 
             this.startDrag();
         }

--- a/source/src/fairygui/Window.ts
+++ b/source/src/fairygui/Window.ts
@@ -37,6 +37,7 @@ namespace fgui {
                     this.removeChild(this._contentPane);
                 this._contentPane = val;
                 if (this._contentPane) {
+                    this._contentPane.name = this._contentPane.name || 'contentPane';
                     this.addChild(this._contentPane);
                     this.setSize(this._contentPane.width, this._contentPane.height);
                     this._contentPane.addRelation(this, RelationType.Size);

--- a/source/src/fairygui/display/Image.ts
+++ b/source/src/fairygui/display/Image.ts
@@ -21,14 +21,9 @@ namespace fgui {
             this._color = "#FFFFFF";
         }
 
-        set_width(value: number) {
-            super.set_width(value);
+        size(width: number, height: number): Laya.Sprite {
             this.markChanged(1);
-        }
-
-        set_height(value: number): void {
-            super.set_height(value);
-            this.markChanged(1);
+            return super.size(width, height);
         }
 
         public get texture(): Laya.Texture {


### PR DESCRIPTION
基于 LayaAir 3.3.0-beta.2 优化适配。
- [修正弹窗展示错误，GRoot.__addedToStage 在添加到舞台时被调用](https://github.com/fairygui/FairyGUI-layabox/commit/b801f4eaf51877dd6dbaf1f85101fc0fa0897e0c)
- [GObject.on 返回回调参数，方便绑定匿名函数时用于解绑的操作](https://github.com/fairygui/FairyGUI-layabox/commit/3ae3b28a3b3b1347c624e0983f197efe61deac00)
- [修正在最新的 Laya 版本中 Image 调整尺寸未能生效的 BUG](https://github.com/fairygui/FairyGUI-layabox/commit/9645e3e8c0e80460048ef1bd1fa5b5dd7f2df944)
- [为 displayObject 设置名字，方便在编辑器中调试 UI 树](https://github.com/fairygui/FairyGUI-layabox/commit/85745521a62bbc3f8a92b8e9fcbcd8b09a172e00)
- [GComponent 添加 onDispose 流程](https://github.com/fairygui/FairyGUI-layabox/pull/90/commits/f54e8b90b9bb89c773fa7f642ebf42bc769c65d9)
- [播放音效时传入 PackageItem 以方便确定是哪个包的音效，支持多个包有相同音效文件名的音效](https://github.com/fairygui/FairyGUI-layabox/pull/90/commits/94ed886e9fa6d26ba5d87e3a38e79007c994d1e0)
- 修正按钮播放音效音量配置未生效的BUG

下载测试 [bin.zip](https://github.com/user-attachments/files/18940642/bin.zip)


